### PR TITLE
fix: remove `year` and `model` from VehicleInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your application's `build.gradle` dependencies:
 
 ```
 dependencies {
-    implementation 'com.smartcar.sdk:smartcar-auth:4.0.0'
+    implementation 'com.smartcar.sdk:smartcar-auth:4.0.2'
 }
 ```
 

--- a/smartcar-auth/build.gradle
+++ b/smartcar-auth/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testAnnotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.1.0'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.robolectric:robolectric:4.13'
 }
 
 /**

--- a/smartcar-auth/gradle.properties
+++ b/smartcar-auth/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=smartcar-auth
-libVersion=4.0.1
+libVersion=4.0.2
 libDescription=Smartcar Android Auth SDK

--- a/smartcar-auth/src/main/java/com/smartcar/sdk/SmartcarAuth.java
+++ b/smartcar-auth/src/main/java/com/smartcar/sdk/SmartcarAuth.java
@@ -300,13 +300,9 @@ public class SmartcarAuth {
             } else if (receivedErrorWithVehicle) {
 
                 String make = uri.getQueryParameter("make");
-                String model = uri.getQueryParameter("model");
-                int year = Integer.parseInt(uri.getQueryParameter("year"));
                 VehicleInfo responseVehicle = new VehicleInfo.Builder()
                     .vin(queryVin)
                     .make(make)
-                    .model(model)
-                    .year(year)
                     .build();
 
                 SmartcarResponse smartcarResponse = responseBuilder

--- a/smartcar-auth/src/main/java/com/smartcar/sdk/VehicleInfo.java
+++ b/smartcar-auth/src/main/java/com/smartcar/sdk/VehicleInfo.java
@@ -6,8 +6,6 @@ package com.smartcar.sdk;
 public class VehicleInfo {
     private String vin;
     private String make;
-    private String model;
-    private Integer year;
 
     /**
      * Assigns properties on the VehicleInfo object.
@@ -17,8 +15,6 @@ public class VehicleInfo {
     private VehicleInfo (Builder builder) {
         this.vin = builder.vin;
         this.make = builder.make;
-        this.model = builder.model;
-        this.year = builder.year;
     }
 
     /**
@@ -39,31 +35,11 @@ public class VehicleInfo {
         return this.vin;
     }
 
-    /**
-     * Returns the model assigned to VehicleInfo
-     *
-     * @return the model of the vehicle
-     */
-    public String getModel() {
-        return this.model;
-    }
-
-    /**
-     * Returns the year assigned to VehicleInfo
-     *
-     * @return the year of the vehicle
-     */
-    public Integer getYear() {
-        return this.year;
-    }
-
     @Override
     public String toString() {
         return "VehicleInfo{" +
                 "vin='" + vin + '\'' +
                 ", make='" + make + '\'' +
-                ", model='" + model + '\'' +
-                ", year=" + year +
                 '}';
     }
 
@@ -73,8 +49,6 @@ public class VehicleInfo {
     public static class Builder {
         private String vin;
         private String make;
-        private String model;
-        private Integer year;
 
         /**
          * Sets the make on the Builder. Including a make allows the user to bypass the car brand
@@ -98,30 +72,6 @@ public class VehicleInfo {
          */
         public Builder vin(String vin) {
             this.vin = vin;
-            return this;
-        }
-
-        /**
-         * Sets the model on the Builder.
-         *
-         * @param model model of the vehicle
-         *
-         * @return the builder with a `model` property added
-         */
-        public Builder model(String model) {
-            this.model = model;
-            return this;
-        }
-
-        /**
-         * Sets the year on the Builder.
-         *
-         * @param year year of the vehicle
-         *
-         * @return the builder with a `year` property added
-         */
-        public Builder year(Integer year) {
-            this.year = year;
             return this;
         }
 

--- a/smartcar-auth/src/test/java/com/smartcar/sdk/SmartcarAuthTest.java
+++ b/smartcar-auth/src/test/java/com/smartcar/sdk/SmartcarAuthTest.java
@@ -286,14 +286,12 @@ public class SmartcarAuthTest {
                 assertEquals(smartcarResponse.getErrorDescription(), "The user's vehicle is not compatible.");
                 assertEquals(responseVehicle.getVin(), "1FDKE30G4JHA04964");
                 assertEquals(responseVehicle.getMake(), "FORD");
-                assertEquals(responseVehicle.getModel(), "E-350");
-                assertEquals(responseVehicle.getYear(), new Integer(1988));
             }
         });
 
         SmartcarAuth.receiveResponse(Uri.parse(redirectUri + "?error=vehicle_incompatible" +
                 "&error_description=The%20user%27s%20vehicle%20is%20not%20compatible." +
-                "&vin=1FDKE30G4JHA04964&make=FORD&model=E-350&year=1988"));
+                "&vin=1FDKE30G4JHA04964&make=FORD"));
     }
 
     @Test

--- a/smartcar-auth/src/test/java/com/smartcar/sdk/SmartcarAuthTest.java
+++ b/smartcar-auth/src/test/java/com/smartcar/sdk/SmartcarAuthTest.java
@@ -23,7 +23,8 @@ public class SmartcarAuthTest {
         String redirectUri = "scclient123://test";
         String redirectUriEncoded = "scclient123%3A%2F%2Ftest";
         String[] scope = {"read_odometer", "read_vin"};
-        String expectedUri = "https://connect.smartcar.com/oauth/authorize?response_type=code" +
+        String expectedUri = "https://connect.smartcar.com/oauth/authorize?response_type=code&sdk_platform=android" +
+                "&sdk_version=" + BuildConfig.VERSION_NAME +
                 "&client_id=" + clientId +
                 "&redirect_uri=" + redirectUriEncoded +
                 "&mode=live&scope=read_odometer%20read_vin";
@@ -41,7 +42,8 @@ public class SmartcarAuthTest {
         String redirectUri = "scclient123://test";
         String redirectUriEncoded = "scclient123%3A%2F%2Ftest";
         String[] scope = {"read_odometer", "read_vin"};
-        String expectedUri = "https://connect.smartcar.com/oauth/authorize?response_type=code" +
+        String expectedUri = "https://connect.smartcar.com/oauth/authorize?response_type=code&sdk_platform=android" +
+                "&sdk_version=" + BuildConfig.VERSION_NAME +
                 "&client_id=" + clientId +
                 "&redirect_uri=" + redirectUriEncoded +
                 "&mode=test&scope=read_odometer%20read_vin";
@@ -62,7 +64,8 @@ public class SmartcarAuthTest {
         String vin = "1234567890ABCDEFG";
         String[] flags = {"flag:suboption", "feature3"};
         String user = "e9b24987-52e8-4d40-8417-bfa4402c9e16";
-        String expectedUri = "https://connect.smartcar.com/oauth/authorize?response_type=code" +
+        String expectedUri = "https://connect.smartcar.com/oauth/authorize?response_type=code&sdk_platform=android" +
+                "&sdk_version=" + BuildConfig.VERSION_NAME +
                 "&client_id=" + clientId +
                 "&redirect_uri=" + redirectUriEncoded +
                 "&mode=live&scope=read_odometer%20read_vin" +

--- a/smartcar-auth/src/test/java/com/smartcar/sdk/SmartcarResponseTest.java
+++ b/smartcar-auth/src/test/java/com/smartcar/sdk/SmartcarResponseTest.java
@@ -59,8 +59,6 @@ public class SmartcarResponseTest {
         VehicleInfo vehicle = new VehicleInfo.Builder()
                 .vin("0000")
                 .make("TESLA")
-                .model("Model S")
-                .year(2019)
                 .build();
 
         SmartcarResponse smartcarResponse = new SmartcarResponse.Builder()


### PR DESCRIPTION
Connect no longer returns `model` and `year` information when vehicle info is returned on the redirect URI when there is an error. This was causing the SDK to crash when a single select vehicle was being returned, because we ended up trying to call `parseInt` on a `null` `year` value from the redirect URI. 

To fix this, I removed `model` and `year` from the `VehicleInfo` object (both setting and getting these params), and then also stopped looking for + parsing the `model` and `year` on the redirect URI as well.

Asana: https://app.asana.com/0/1209055054708910/1208896708918648