### PR TITLE
[EXP-1058] fix: only append sdk_platform/version if the param doesn't already exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your application's `build.gradle` dependencies:
 
 ```
 dependencies {
-    implementation("com.smartcar.sdk:smartcar-auth:4.1.0")
+    implementation("com.smartcar.sdk:smartcar-auth:4.1.1")
 }
 ```
 

--- a/smartcar-auth/gradle.properties
+++ b/smartcar-auth/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=smartcar-auth
-libVersion=4.1.0
+libVersion=4.1.1
 libDescription=Smartcar Android Auth SDK

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
@@ -304,11 +304,22 @@ class SmartcarAuth {
      * @param authUrl Use {@link AuthUrlBuilder} to generate the authorization url
      */
     fun launchAuthFlow(context: Context, authUrl: String) {
-        // Append sdk version query parameters
-        val newAuthUrl = authUrl.toUri().buildUpon()
-            .appendQueryParameter("sdk_platform", "android")
-            .appendQueryParameter("sdk_version", BuildConfig.VERSION_NAME)
-            .build()
+        // Append sdk version query parameters if they don't already exist
+
+        val uri = authUrl.toUri()
+        val uriBuilder = uri.buildUpon()
+        
+        // Check if sdk_platform parameter already exists
+        if (uri.getQueryParameter("sdk_platform") == null) {
+            uriBuilder.appendQueryParameter("sdk_platform", "android")
+        }
+        
+        // Check if sdk_version parameter already exists
+        if (uri.getQueryParameter("sdk_version") == null) {
+            uriBuilder.appendQueryParameter("sdk_version", BuildConfig.VERSION_NAME)
+        }
+        
+        val newAuthUrl = uriBuilder.build()
 
         val intent = Intent(context, ConnectActivity::class.java)
         intent.putExtra("authorize_url", newAuthUrl.toString())

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
@@ -149,8 +149,6 @@ class SmartcarAuth {
     inner class AuthUrlBuilder {
         private val uriBuilder = BASE_AUTHORIZATION_URL.toUri().buildUpon()
                 .appendQueryParameter("response_type", "code")
-                .appendQueryParameter("sdk_platform", "android")
-                .appendQueryParameter("sdk_version", BuildConfig.VERSION_NAME)
                 .appendQueryParameter("client_id", clientId)
                 .appendQueryParameter("redirect_uri", redirectUri)
                 .appendQueryParameter("mode", if (testMode) "test" else "live")


### PR DESCRIPTION
For users that were using the SDK to build their auth URL, the `sdk_platform` and `sdk_version` params were being duplicated. Only add these params if they don't already exist in the authUrl being used to launch the auth flow.