### PR TITLE
[EXP-1024] feat: make scope parameter optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your application's `build.gradle` dependencies:
 
 ```
 dependencies {
-    implementation("com.smartcar.sdk:smartcar-auth:4.1.1")
+    implementation("com.smartcar.sdk:smartcar-auth:4.1.2")
 }
 ```
 

--- a/smartcar-auth/gradle.properties
+++ b/smartcar-auth/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=smartcar-auth
-libVersion=4.1.1
+libVersion=4.1.2
 libDescription=Smartcar Android Auth SDK

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
@@ -35,7 +35,7 @@ class SmartcarAuth {
 
         private lateinit var clientId: String
         private lateinit var redirectUri: String
-        private lateinit var scope: Array<String>
+        private var scope: Array<String> = emptyArray()
         private var testMode: Boolean = false
         private lateinit var callback: SmartcarCallback
 
@@ -112,6 +112,25 @@ class SmartcarAuth {
      *
      * @param clientId    The client's ID
      * @param redirectUri The client's redirect URI
+     * @param callback    Handler to a Callback for receiving the Smartcar Connect response
+     */
+    constructor(clientId: String, redirectUri: String, callback: SmartcarCallback) : this(clientId, redirectUri, emptyArray(), false, callback)
+
+    /**
+     * Constructs an instance with the given parameters.
+     *
+     * @param clientId    The client's ID
+     * @param redirectUri The client's redirect URI
+     * @param testMode    Set to true to run Smartcar Connect in test mode
+     * @param callback    Handler to a Callback for receiving the Smartcar Connect response
+     */
+    constructor(clientId: String, redirectUri: String, testMode: Boolean, callback: SmartcarCallback) : this(clientId, redirectUri, emptyArray(), testMode, callback)
+
+    /**
+     * Constructs an instance with the given parameters.
+     *
+     * @param clientId    The client's ID
+     * @param redirectUri The client's redirect URI
      * @param scope       An array of authorization scopes
      * @param callback    Handler to a Callback for receiving the Smartcar Connect response
      */
@@ -152,7 +171,11 @@ class SmartcarAuth {
                 .appendQueryParameter("client_id", clientId)
                 .appendQueryParameter("redirect_uri", redirectUri)
                 .appendQueryParameter("mode", if (testMode) "test" else "live")
-                .appendQueryParameter("scope", TextUtils.join(" ", scope))
+                .apply {
+                    if (scope.isNotEmpty()) {
+                        appendQueryParameter("scope", TextUtils.join(" ", scope))
+                    }
+                }
 
         /**
          * Set an optional state parameter.

--- a/smartcar-auth/src/androidUnitTest/kotlin/com/smartcar/sdk/SmartcarAuthTest.kt
+++ b/smartcar-auth/src/androidUnitTest/kotlin/com/smartcar/sdk/SmartcarAuthTest.kt
@@ -55,6 +55,42 @@ class SmartcarAuthTest {
     }
 
     @Test
+    fun smartcarAuth_authUrlBuilder_noScopeOrTestMode() {
+        val clientId = "client123"
+        val redirectUri = "scclient123://test"
+        val redirectUriEncoded = "scclient123%3A%2F%2Ftest"
+        val expectedUri =
+            "https://connect.smartcar.com/oauth/authorize?response_type=code" +
+                    "&client_id=" + clientId +
+                    "&redirect_uri=" + redirectUriEncoded +
+                    "&mode=live"
+
+
+        val smartcarAuth = SmartcarAuth(clientId, redirectUri) {}
+        val requestUri = smartcarAuth.authUrlBuilder().build()
+
+        Assert.assertEquals(expectedUri, requestUri)
+    }
+
+    @Test
+    fun smartcarAuth_authUrlBuilder_noScope() {
+        val clientId = "client123"
+        val redirectUri = "scclient123://test"
+        val redirectUriEncoded = "scclient123%3A%2F%2Ftest"
+        val expectedUri =
+            "https://connect.smartcar.com/oauth/authorize?response_type=code" +
+                    "&client_id=" + clientId +
+                    "&redirect_uri=" + redirectUriEncoded +
+                    "&mode=test"
+
+
+        val smartcarAuth = SmartcarAuth(clientId, redirectUri, true) {}
+        val requestUri = smartcarAuth.authUrlBuilder().build()
+
+        Assert.assertEquals(expectedUri, requestUri)
+    }
+
+    @Test
     fun smartcarAuth_authUrlBuilderWithSetters() {
         val clientId = "client123"
         val redirectUri = "scclient123://test"

--- a/smartcar-auth/src/androidUnitTest/kotlin/com/smartcar/sdk/SmartcarAuthTest.kt
+++ b/smartcar-auth/src/androidUnitTest/kotlin/com/smartcar/sdk/SmartcarAuthTest.kt
@@ -65,7 +65,6 @@ class SmartcarAuthTest {
                     "&redirect_uri=" + redirectUriEncoded +
                     "&mode=live"
 
-
         val smartcarAuth = SmartcarAuth(clientId, redirectUri) {}
         val requestUri = smartcarAuth.authUrlBuilder().build()
 
@@ -82,7 +81,6 @@ class SmartcarAuthTest {
                     "&client_id=" + clientId +
                     "&redirect_uri=" + redirectUriEncoded +
                     "&mode=test"
-
 
         val smartcarAuth = SmartcarAuth(clientId, redirectUri, true) {}
         val requestUri = smartcarAuth.authUrlBuilder().build()


### PR DESCRIPTION
Removes the requirement for the `scope` parameter since the developer's Vehicle Access settings will be used as a fallback.