### PR TITLE
fix: allow opening external URLs in connect webview

### DIFF
--- a/smartcar-auth/gradle.properties
+++ b/smartcar-auth/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=smartcar-auth
-libVersion=4.1.3
+libVersion=4.1.4
 libDescription=Smartcar Android Auth SDK

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
@@ -31,7 +31,6 @@ class SmartcarAuth {
 
     internal companion object {
         private const val BASE_AUTHORIZATION_URL = "https://connect.smartcar.com/oauth/authorize"
-        private const val AUTHORIZATION_HOST = "connect.smartcar.com"
 
         private lateinit var clientId: String
         private lateinit var redirectUri: String
@@ -329,24 +328,23 @@ class SmartcarAuth {
 
         val uri = authUrl.toUri()
         val uriBuilder = uri.buildUpon()
-        
+
         // Check if sdk_platform parameter already exists
         if (uri.getQueryParameter("sdk_platform") == null) {
             uriBuilder.appendQueryParameter("sdk_platform", "android")
         }
-        
+
         // Check if sdk_version parameter already exists
         if (uri.getQueryParameter("sdk_version") == null) {
             uriBuilder.appendQueryParameter("sdk_version", BuildConfig.VERSION_NAME)
         }
-        
+
         val newAuthUrl = uriBuilder.build()
 
         val intent = Intent(context, ConnectActivity::class.java)
         intent.putExtra("authorize_url", newAuthUrl.toString())
         intent.putExtra("intercept_prefix", redirectUri)
-        if (newAuthUrl.host == AUTHORIZATION_HOST)
-            intent.putExtra("allowed_host", AUTHORIZATION_HOST)
+        intent.putExtra("allowed_host", newAuthUrl.host)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         context.startActivity(intent)
     }

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/ConnectActivity.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/ConnectActivity.kt
@@ -9,20 +9,50 @@ import com.smartcar.sdk.rpc.ble.BLEService
 import com.smartcar.sdk.rpc.oauth.OAuthService
 
 class ConnectActivity : WebViewActivity() {
-    private lateinit var oauthService: OAuthService
-    private lateinit var bleService: BLEService
+    private var oauthService: OAuthService? = null
+    private var bleService: BLEService? = null
+    private lateinit var oauthBridge: WebViewBridgeImpl
+    private lateinit var bleBridge: WebViewBridgeImpl
 
     override fun initWebView(webView: WebView) {
-        oauthService = OAuthService(ContextBridgeImpl(this), WebViewBridgeImpl(webView, "SmartcarSDK"))
-        bleService = BLEService(ContextBridgeImpl(this), WebViewBridgeImpl(webView, "SmartcarSDKBLE"))
+        oauthBridge = WebViewBridgeImpl(webView, "SmartcarSDK")
+        bleBridge = WebViewBridgeImpl(webView, "SmartcarSDKBLE")
 
         super.initWebView(webView)
     }
 
-    override fun onDestroyWebView(webView: WebView) {
-        oauthService.dispose()
-        bleService.dispose()
+    override fun onAllowedHostChanged(isAllowedHost: Boolean) {
+        if (!::oauthBridge.isInitialized || !::bleBridge.isInitialized) return
 
+        if (isAllowedHost) {
+            if (oauthService == null) {
+                oauthService = OAuthService(ContextBridgeImpl(this), oauthBridge)
+            }
+            if (bleService == null) {
+                bleService = BLEService(ContextBridgeImpl(this), bleBridge)
+            }
+            oauthBridge.attachJavascriptInterface()
+            bleBridge.attachJavascriptInterface()
+        } else {
+            destroyServices()
+        }
+    }
+
+    private fun destroyServices() {
+        if (::oauthBridge.isInitialized) {
+            oauthBridge.detachJavascriptInterface()
+        }
+        if (::bleBridge.isInitialized) {
+            bleBridge.detachJavascriptInterface()
+        }
+        oauthService?.dispose()
+        bleService?.dispose()
+        oauthService = null
+        bleService = null
+    }
+
+    override fun onDestroyWebView(webView: WebView) {
+        destroyServices()
         super.onDestroyWebView(webView)
     }
 

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/WebViewActivity.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/WebViewActivity.kt
@@ -10,6 +10,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
+import androidx.core.net.toUri
 import com.smartcar.sdk.bridge.ContextBridgeImpl
 import com.smartcar.sdk.rpc.oauth.HeaderConfig
 import kotlinx.serialization.json.Json
@@ -69,6 +70,8 @@ open class WebViewActivity : ComponentActivity() {
 
         // Load the URL
         authorizeURL?.let {
+            checkAllowedHost(it.toUri(), allowedHost)
+
             val headers = getAdditionalHeaders(it)
             // Set the user agent if specified
             getUserAgentFromHeaders(headers)?.let { userAgent ->
@@ -102,6 +105,14 @@ open class WebViewActivity : ComponentActivity() {
         finish()
     }
 
+    open fun onAllowedHostChanged(isAllowedHost: Boolean) {
+    }
+
+    private fun checkAllowedHost(url: Uri, allowedHost: String?) {
+        onAllowedHostChanged(allowedHost == null ||
+                url.host.equals(allowedHost, ignoreCase = true))
+    }
+
     inner class CustomWebViewClient(
         private val interceptPrefix: String?,
         private val allowedHost: String?
@@ -123,14 +134,7 @@ open class WebViewActivity : ComponentActivity() {
                     return true
                 }
 
-                // Check if the URL matches the allowed hostname, if specified
-                if (allowedHost != null && url.host != allowedHost) {
-                    Log.d("OAuthCapture", "Opening external URL: $url")
-                    Intent(Intent.ACTION_VIEW, url).apply {
-                        startActivity(this)
-                    }
-                    return true
-                }
+                checkAllowedHost(url, allowedHost)
 
                 // Load with custom headers if applicable
                 val headers = getAdditionalHeaders(url.toString())

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/bridge/WebViewBridgeImpl.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/bridge/WebViewBridgeImpl.kt
@@ -5,7 +5,7 @@ import android.webkit.WebView
 
 class WebViewBridgeImpl(
     private val webView: WebView,
-    channelName: String,
+    private val channelName: String,
 ): WebViewBridge {
 
     override lateinit var onMessageFromJS: ((String) -> Unit)
@@ -17,10 +17,19 @@ class WebViewBridgeImpl(
             onMessageFromJS.invoke(message)
         }
     }
+    private val jsInterface = JSInterface()
+    private var isJavascriptInterfaceAttached = false
 
-    init {
-        // Add the JavaScript interface to the WebView.
-        webView.addJavascriptInterface(JSInterface(), channelName)
+    fun attachJavascriptInterface() {
+        if (isJavascriptInterfaceAttached) return
+        webView.addJavascriptInterface(jsInterface, channelName)
+        isJavascriptInterfaceAttached = true
+    }
+
+    fun detachJavascriptInterface() {
+        if (!isJavascriptInterfaceAttached) return
+        webView.removeJavascriptInterface(channelName)
+        isJavascriptInterfaceAttached = false
     }
 
     override fun evaluateJavaScript(script: String, callback: (String?) -> Unit) {


### PR DESCRIPTION
Allow opening external URLs in connect webview, while restricting the RPC interface to our first-party site