### PR TITLE
fix: skip dokka for cd process

### DIFF
--- a/.buddy/cd.yml
+++ b/.buddy/cd.yml
@@ -25,7 +25,7 @@
     - "export ORG_GRADLE_PROJECT_signingKey=\"$(cat /buddy-variables/cismartcar_com_pgp)\""
     - "# Publish"
     - ""
-    - "./gradlew --no-configuration-cache publishAndroidReleasePublicationToSonatypeRepository closeAndReleaseStagingRepositories"
+    - "./gradlew --no-configuration-cache --no-daemon -x :smartcar-auth:commonizeNativeDistribution -Pkotlin.native.ignoreDisabledTargets=true -PskipDokkaForPublish=true publishAndroidReleasePublicationToSonatypeRepository closeAndReleaseStagingRepositories"
     - ""
     - ""
     setup_commands:

--- a/smartcar-auth/build.gradle.kts
+++ b/smartcar-auth/build.gradle.kts
@@ -16,6 +16,10 @@ val libGroup: String by project
 val libName: String by project
 val libVersion: String by project
 val libDescription: String by project
+val skipDokkaForPublish = providers
+    .gradleProperty("skipDokkaForPublish")
+    .map(String::toBoolean)
+    .orElse(false)
 
 group = libGroup
 version = libVersion
@@ -179,7 +183,14 @@ publishing {
 // Task to generate documentation with Dokka and package it as a JAR
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")
-    from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
+    if (skipDokkaForPublish.get()) {
+        // Keep Maven Central-compatible javadoc artifact when Dokka is skipped in CI publish jobs.
+        doFirst {
+            logger.lifecycle("Skipping Dokka and creating empty javadoc JAR (skipDokkaForPublish=true)")
+        }
+    } else {
+        from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
+    }
 }
 
 /**


### PR DESCRIPTION
Copilot:

Dokka is Kotlin’s documentation generator.
Think of it as the Kotlin equivalent of Javadoc: it reads your source and produces API docs (HTML/Javadoc-style output), which are often packaged as a javadoc jar for Maven Central publishing.

Why we’re skipping it in this CD path:

Your CD job is Android artifact publishing on Linux.
This project is Kotlin Multiplatform with iOS/native targets, and Dokka in this setup ends up depending on native commonization work.
The pipeline was failing in that dependency chain (first memory kill, then task graph conflict when native commonization was excluded).
For this specific publish path, generating full docs is not essential to produce and release the Android AAR, so we use an empty javadoc jar instead to satisfy publishing requirements.
Important scope detail:

We are not removing Dokka globally.
We only skip it when the property is passed in CD:
[build.gradle.kts:14](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[build.gradle.kts:185](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
The property is only set in the CD command:
[cd.yml:28](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
So: Dokka is still available for normal/local doc generation; it is just bypassed in this fragile CI release path to keep releases unblocked.