### PR TITLE
fix(ENG-2228): deliver a user_exited callback when the user dismisses Connect

### DIFF
--- a/smartcar-auth/gradle.properties
+++ b/smartcar-auth/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=smartcar-auth
-libVersion=4.3.0
+libVersion=4.3.1
 libDescription=Smartcar Android Auth SDK

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
@@ -163,7 +163,7 @@ class SmartcarAuth {
          * (success/error arrives before the activity finishes) or the callback was lost to
          * process death.
          */
-        fun dispatchUserExitedIfNoResponse() {
+        internal fun dispatchUserExitedIfNoResponse() {
             if (!::callback.isInitialized || responseDelivered) return
             responseDelivered = true
             val smartcarResponse = SmartcarResponse.Builder()

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/SmartcarAuth.kt
@@ -41,6 +41,9 @@ class SmartcarAuth {
         private var testMode: Boolean = false
         private lateinit var callback: SmartcarCallback
         private var responseType: String = "code"
+        // True once a response (success/error) has been delivered for the current flow.
+        // Guards the user_exited dispatch so a completed flow isn't also reported as a cancel.
+        private var responseDelivered: Boolean = false
 
         /**
          * Turns raw result fields into a [SmartcarResponse] and hands it to [callback]. Shared
@@ -66,6 +69,9 @@ class SmartcarAuth {
              * major version by migrating to the ContextBridge/Activity Results pattern.
              */
             if (!::callback.isInitialized) return
+            // Mark the flow as answered so a subsequent activity-dismissal doesn't also
+            // deliver a user_exited response.
+            responseDelivered = true
 
             val receivedCode = code != null
             val receivedError = error != null && vin == null
@@ -147,6 +153,24 @@ class SmartcarAuth {
                     virtualKeyUrl = uri.getQueryParameter("virtual_key_url")
                 )
             }
+        }
+
+        /**
+         * Delivers a `user_exited` response when Connect's activity is finishing without a
+         * result having been delivered (the user dismissed the flow via back press or swipe).
+         * Lets callers distinguish a user cancel from a hang, matching the iOS SDK's
+         * AuthorizationError.userExitedFlow. No-op when a response was already delivered
+         * (success/error arrives before the activity finishes) or the callback was lost to
+         * process death.
+         */
+        fun dispatchUserExitedIfNoResponse() {
+            if (!::callback.isInitialized || responseDelivered) return
+            responseDelivered = true
+            val smartcarResponse = SmartcarResponse.Builder()
+                    .error("user_exited")
+                    .errorDescription("User exited Smartcar Connect before completing the flow")
+                    .build()
+            callback.handleResponse(smartcarResponse)
         }
 
         /**
@@ -242,6 +266,7 @@ class SmartcarAuth {
         Companion.testMode = testMode
         Companion.responseType = responseType
         Companion.callback = callback
+        Companion.responseDelivered = false
     }
 
     /**

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/ConnectActivity.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/ConnectActivity.kt
@@ -51,6 +51,17 @@ class ConnectActivity : WebViewActivity() {
         bleService = null
     }
 
+    override fun onDestroy() {
+        // If the user dismissed Connect (back press / swipe-away) the activity is finishing
+        // and no redirect was intercepted, so deliver a user_exited response. isFinishing is
+        // false for configuration changes (rotation) and while backgrounded for OEM
+        // app-to-app handoff, so this does not false-fire mid-flow.
+        if (isFinishing) {
+            SmartcarAuth.dispatchUserExitedIfNoResponse()
+        }
+        super.onDestroy()
+    }
+
     override fun onDestroyWebView(webView: WebView) {
         destroyServices()
         super.onDestroyWebView(webView)

--- a/smartcar-auth/src/androidUnitTest/kotlin/com/smartcar/sdk/SmartcarAuthTest.kt
+++ b/smartcar-auth/src/androidUnitTest/kotlin/com/smartcar/sdk/SmartcarAuthTest.kt
@@ -714,4 +714,45 @@ class SmartcarAuthTest {
             CompleteRequest.CompleteParams(userId = "user-123", externalId = "abc123")
         )
     }
+
+    @Test
+    fun smartcarAuth_dispatchUserExitedIfNoResponse_deliversUserExited() {
+        val applicationId = "client123"
+        val redirectUri = "scclient123://test"
+        val scope = arrayOf("read_odometer", "read_vin")
+
+        var callbackCount = 0
+        SmartcarAuth(applicationId, redirectUri, scope, false, "none") { smartcarResponse ->
+            callbackCount++
+            Assert.assertEquals("user_exited", smartcarResponse!!.error)
+            Assert.assertEquals(null, smartcarResponse.code)
+            Assert.assertEquals(null, smartcarResponse.userId)
+        }
+
+        SmartcarAuth.dispatchUserExitedIfNoResponse()
+
+        Assert.assertEquals(1, callbackCount)
+    }
+
+    @Test
+    fun smartcarAuth_dispatchUserExitedIfNoResponse_noOpAfterResponseDelivered() {
+        val applicationId = "client123"
+        val redirectUri = "scclient123://test"
+        val scope = arrayOf("read_odometer", "read_vin")
+
+        var userExitedDelivered = false
+        SmartcarAuth(applicationId, redirectUri, scope) { smartcarResponse ->
+            if (smartcarResponse?.error == "user_exited") userExitedDelivered = true
+        }
+
+        // A real response arrives first (marks the flow answered)...
+        SmartcarAuth.receiveResponse(Uri.parse("$redirectUri?code=testcode123"), redirectUri)
+        // ...so a later dismissal must NOT also deliver a user_exited response.
+        SmartcarAuth.dispatchUserExitedIfNoResponse()
+
+        Assert.assertFalse(
+            "user_exited must not fire after a response was already delivered",
+            userExitedDelivered
+        )
+    }
 }


### PR DESCRIPTION
Linear: ENG-2228

**Problem.** On Android, dismissing Connect (back press / swipe) fires no `SmartcarCallback` — the callback only runs on redirect interception (`ConnectActivity.onInterceptUri`). Developers can't distinguish a user cancel from a hang and resort to activity-foreground heuristics. iOS already surfaces this as `AuthorizationError.userExitedFlow`; Android has no equivalent.

**Fix.** When `ConnectActivity` is finishing without a response delivered, dispatch `handleResponse` with `error="user_exited"`. A `responseDelivered` guard ensures a completed flow is never also reported as a cancel; `isFinishing` excludes config changes and OEM app-to-app backgrounding.

**Compatibility.** Additive. `SmartcarCallback` is a single-method `fun interface` (unchanged) and `SmartcarResponse.error` is already `String?` — the new value rides existing fields. No signature/type change. Developers should map `user_exited` to a cancel (as the iOS SDK does) rather than a generic failure; release notes should call this out.

Targets a minor release (4.4.0).