### PR TITLE
fix: handle Connect new-tab links

### DIFF
--- a/smartcar-auth/gradle.properties
+++ b/smartcar-auth/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=smartcar-auth
-libVersion=4.3.1
+libVersion=4.3.2
 libDescription=Smartcar Android Auth SDK

--- a/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/ConnectActivity.kt
+++ b/smartcar-auth/src/androidMain/kotlin/com/smartcar/sdk/activity/ConnectActivity.kt
@@ -1,8 +1,15 @@
 package com.smartcar.sdk.activity
 
 import com.smartcar.sdk.bridge.ContextBridgeImpl
+import android.content.Intent
 import android.net.Uri
+import android.os.Message
+import android.util.Log
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.core.net.toUri
 import com.smartcar.sdk.SmartcarAuth
 import com.smartcar.sdk.bridge.WebViewBridgeImpl
 import com.smartcar.sdk.rpc.ble.BLEService
@@ -17,6 +24,15 @@ class ConnectActivity : WebViewActivity() {
     override fun initWebView(webView: WebView) {
         oauthBridge = WebViewBridgeImpl(webView, "SmartcarSDK")
         bleBridge = WebViewBridgeImpl(webView, "SmartcarSDKBLE")
+
+        // Connect uses a target="_blank" link for certain operations and expects it to open in
+        // a new tab so that Connect remains active underneath. WebView ignores that by default and
+        // navigates this WebView away instead — send it to an external browser so Connect
+        // isn't replaced. We deliberately don't set javaScriptCanOpenWindowsAutomatically:
+        // Connect has no legitimate reason to call window.open() itself, so leaving it at
+        // its default (false) means only a real user tap can reach onCreateWindow at all.
+        webView.settings.setSupportMultipleWindows(true)
+        webView.webChromeClient = NewWindowChromeClient()
 
         super.initWebView(webView)
     }
@@ -70,5 +86,52 @@ class ConnectActivity : WebViewActivity() {
     override fun onInterceptUri(uri: Uri, interceptPrefix: String) {
         SmartcarAuth.receiveResponse(uri, interceptPrefix)
         super.onInterceptUri(uri, interceptPrefix)
+    }
+
+    /**
+     * Handles target="_blank" links, which WebView otherwise silently drops. There's no
+     * second screen to show a real new window in here, so this catches the URL the page
+     * wanted to open in one and hands it to an external browser, leaving Connect's current
+     * page untouched.
+     */
+    inner class NewWindowChromeClient : WebChromeClient() {
+        override fun onCreateWindow(
+            view: WebView,
+            isDialog: Boolean,
+            isUserGesture: Boolean,
+            resultMsg: Message
+        ): Boolean {
+            val popup = WebView(view.context)
+            popup.webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    popupView: WebView,
+                    request: WebResourceRequest
+                ): Boolean {
+                    openExternally(request.url)
+                    return true
+                }
+
+                override fun onPageStarted(popupView: WebView, url: String?, favicon: android.graphics.Bitmap?) {
+                    url?.let { openExternally(it.toUri()) }
+                    popup.stopLoading()
+                    popup.destroy()
+                }
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            val transport = resultMsg.obj as WebView.WebViewTransport
+            transport.webView = popup
+            resultMsg.sendToTarget()
+            return true
+        }
+
+        private fun openExternally(url: Uri) {
+            Log.d("OAuthCapture", "onCreateWindow: opening new-tab URL externally: $url")
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, url))
+            } catch (error: Exception) {
+                Log.w("OAuthCapture", "Failed to open new-tab URL: $url", error)
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes Android Connect breaking when a step (e.g. Tesla's "Continue to Tesla"
virtual-key-pairing link) uses `target="_blank"`, expecting it to open in a new tab so
Connect stays alive underneath.

- `WebView` silently ignores `target="_blank"` by default — instead of opening a new
  tab, it just navigates the current `WebView` away, replacing Connect with the linked
  page and leaving the user with no way back.
- `ConnectActivity` now implements `WebChromeClient.onCreateWindow` to catch that
  request and hand the URL to the device's external browser instead, leaving Connect's
  own `WebView` untouched.
- Scoped to `ConnectActivity` only (not the shared `WebViewActivity` base).
  `javaScriptCanOpenWindowsAutomatically` is deliberately left at its default `false` —
  Connect has no legitimate reason to open a window via script, so only a real user tap
  can reach `onCreateWindow`.

## Test plan

- [x] Tapped the "Continue to Tesla" link on a Pixel emulator and confirmed it opens in
      the external browser instead of replacing Connect
- [x] Confirmed via the app switcher that Connect remains alive/unchanged underneath
      after the external browser opens
- [x] Confirm navigation to OEM redirect links in the same tab as expected